### PR TITLE
Center article toolbar images

### DIFF
--- a/reeder.css
+++ b/reeder.css
@@ -684,9 +684,10 @@ img[src*="plugins/article_toolbar/images/down.png"] {
 
 button.button_nav img {
   background-color: transparent !important;
+  background-position: center center !important;
   background-repeat: no-repeat !important;
   height: 24px !important;
-  padding-right: 24px;
+  padding-right: 18px;
   width: 0 !important;
   display: inline-block;
 }


### PR DESCRIPTION
Hi,

The pictures displayed on the article_toolbar buttons were not centered. This was particularly visible when hovering the mouse over the icons, due to the darker background.

This should fix the issue.
The change has been tested with both article_toolbar and article_toolbar_small on Firefox and IE.

Hope this helps...
MF.
