### PR TITLE
Use https to fetch Open Sans font

### DIFF
--- a/reeder.css
+++ b/reeder.css
@@ -3,7 +3,7 @@ Tiny Tiny RSS Reeder Theme
 Author: zas
 Email: zaswiki@gmail.com
 */
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,800italic,400,600,700,800);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,800italic,400,600,700,800);
 @import "default.css";
 /************************************************************
 * Global Settings


### PR DESCRIPTION
Hi,

Here is a patch to fetch the Open Sans font via https instead of http.
This was flagged by recent Firefox version, due to the new mixed content blocking system.

Thanks,
MF.
