### PR TITLE
Bump supported tt-rss version

### DIFF
--- a/reeder.css
+++ b/reeder.css
@@ -1,4 +1,4 @@
-/* supports-version:15.7 */
+/* supports-version:16.1 */
 @import url(reeder/claro-mod.min.css);
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800);
 


### PR DESCRIPTION
There doesn't seem to be any change that breaks the theme, but more testing might reveal something I've missed.