### PR TITLE
Bump supported tt-rss version to 16.3

### DIFF
--- a/reeder.css
+++ b/reeder.css
@@ -1,4 +1,4 @@
-/* supports-version:16.1 */
+/* supports-version:16.3 */
 @import url(reeder/claro-mod.min.css);
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800);
 


### PR DESCRIPTION
TT-RSS has again updated its version number.

My own testing has uncovered no problems.