### PR TITLE
Updated supports-version to 16.8

### DIFF
--- a/reeder.css
+++ b/reeder.css
@@ -1,4 +1,4 @@
-/* supports-version:16.3 */
+/* supports-version:16.8 */
 @import url(reeder/claro-mod.min.css);
 @import url(//fonts.googleapis.com/css?family=Open+Sans:400,700,300,600,800);
 


### PR DESCRIPTION
The theme won't work with the newest tt-rss-Releases when the supports-version is not set correctly.